### PR TITLE
Remove OWASP reference from standard TDP ruleset

### DIFF
--- a/spectral.yaml
+++ b/spectral.yaml
@@ -1,6 +1,5 @@
 extends:
   - spectral:oas
-  - https://unpkg.com/@stoplight/spectral-owasp-ruleset@1.1.1/dist/ruleset.js
 functionsDir: "./functions"
 functions:
   - operation-summary-description


### PR DESCRIPTION
Added this as part of case TDP-470 but immediately ran into problems with larger spec files. Will remove from here and find another approach