### PR TITLE
Update actions/checkout which uses Node 16

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Run Spectral
       - uses: stoplightio/spectral-action@latest


### PR DESCRIPTION
Update actions/checkout which uses Node 16. Will get rid of the warning in each Action workflow.

REF: https://github.com/actions/checkout