### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete regular expression for hostnames

### DIFF
--- a/functions/valid-url-checker.js
+++ b/functions/valid-url-checker.js
@@ -2,7 +2,7 @@ module.exports = (input) => {
   for (let index in input) {
     let url = input[index]["url"];
     var re =
-    /(^(https:\/\/)(((eu|us)(-aws|-az)(.api.trimble.com\/)(product\/{1}))|(cloud((.dev|.qa.|.stage){0,}.api.(trimblecloud|trimble)).com\/cloud\/{1}))([-a-z0-9]{0,}\/{1})(v[1-9]{1}[0-9]{0,14}(-dev|-qa|-stage)?)(\/[a-z0-9]{0,}){0,}((?<=\/)([a-z]{0,})(((?<=[a-z])([-_0-9]{0,}))((?<=[-_])([a-z0-9]{1,})))(?<!\/)(\/){0,1})*)$/;
+    /(^(https:\/\/)(((eu|us)(-aws|-az)(\.api\.trimble\.com\/)(product\/{1}))|(cloud((\.dev|\.qa\.|\.stage){0,}\.api\.(trimblecloud|trimble))\.com\/cloud\/{1}))([-a-z0-9]{0,}\/{1})(v[1-9]{1}[0-9]{0,14}(-dev|-qa|-stage)?)(\/[a-z0-9]{0,}){0,}((?<=\/)([a-z]{0,})(((?<=[a-z])([-_0-9]{0,}))((?<=[-_])([a-z0-9]{1,})))(?<!\/)(\/){0,1})*)$/;
 
     var valid = re.test(url);
 


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/openapi-spectral-rules/security/code-scanning/3](https://github.com/trimble-oss/openapi-spectral-rules/security/code-scanning/3)

To fix the problem, we need to escape all `.` characters in the regular expression that are meant to match literal dots in hostnames. Specifically, in the segment `cloud((.dev|.qa.|.stage){0,}.api.(trimblecloud|trimble)).com\/cloud\/{1}`, the dots in `.dev`, `.qa.`, `.stage`, `.api`, `.com`, and similar should be replaced with `\.`. This ensures the regex matches only the intended hostnames and does not allow arbitrary characters in place of dots. The change should be made directly in the regex definition on line 5 of `functions/valid-url-checker.js`. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
