### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: NPM test
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/openapi-spectral-rules/security/code-scanning/1](https://github.com/trimble-oss/openapi-spectral-rules/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to read repository contents, so the `permissions` block should be set to `contents: read`. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specified job). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made at the top of the `.github/workflows/test.yml` file, immediately after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
