### PR TITLE
Add @jbendtr as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jbendtr @CarrieRaglan

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,4 @@
-
 | Name            | Username          |
 |-----------------|-------------------|
-| Jeff Bendixsen  | [jbend](https://github.com/jbend)     |
+| Jeff Bendixsen  | [jbendtr](https://github.com/jbendtr)     |
 | Carrie Raglan  | [CarrieRaglan](https://github.com/CarrieRaglan)     |


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` with `@jbendtr` and `@CarrieRaglan` (current maintainers)
- Update `MAINTAINERS.md` username from legacy `@jbend` to `@jbendtr`

## Test plan
- [ ] Confirm CODEOWNERS file is recognized by GitHub
- [ ] Confirm `@jbendtr` is listed as a code owner on new PRs
- [ ] Confirm MAINTAINERS.md links to the correct GitHub profile


Made with [Cursor](https://cursor.com)